### PR TITLE
corrected navbar-brand text

### DIFF
--- a/docs/contribute/helptimeconv.html
+++ b/docs/contribute/helptimeconv.html
@@ -14,7 +14,7 @@
     <body>
       <nav class="navbar navbar-expand-sm bg-dark navbar-dark">
         <div class="container-fluid">
-          <a class="navbar-brand" href="../index.html">Navbar</a>
+          <a class="navbar-brand" href="../index.html">TimeConv</a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#collapsibleNavbar">
           <span class="navbar-toggler-icon"></span>
           </button>

--- a/docs/credits.html
+++ b/docs/credits.html
@@ -12,7 +12,7 @@
       <body>
          <nav class="navbar navbar-expand-sm bg-dark navbar-dark">
             <div class="container-fluid">
-               <a class="navbar-brand" href="index.html">Navbar</a>
+               <a class="navbar-brand" href="index.html">TimeConv</a>
                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#collapsibleNavbar">
                <span class="navbar-toggler-icon"></span>
                </button>

--- a/docs/datetimetoutc.html
+++ b/docs/datetimetoutc.html
@@ -13,7 +13,7 @@
     <body>
       <nav class="navbar navbar-expand-sm bg-dark navbar-dark">
         <div class="container-fluid">
-          <a class="navbar-brand" href="index.html">Navbar</a>
+          <a class="navbar-brand" href="index.html">TimeConv</a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#collapsibleNavbar">
           <span class="navbar-toggler-icon"></span>
           </button>

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
   <body>
     <nav class="navbar navbar-expand-sm bg-dark navbar-dark">
       <div class="container-fluid">
-        <a class="navbar-brand" href="index.html">Navbar</a>
+        <a class="navbar-brand" href="index.html">TimeConv</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#collapsibleNavbar">
           <span class="navbar-toggler-icon"></span>
         </button>

--- a/docs/legal/branding.html
+++ b/docs/legal/branding.html
@@ -12,7 +12,7 @@
     <body>
       <nav class="navbar navbar-expand-sm bg-dark navbar-dark">
         <div class="container-fluid">
-          <a class="navbar-brand" href="../index.html">Navbar</a>
+          <a class="navbar-brand" href="../index.html">TimeConv</a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#collapsibleNavbar">
           <span class="navbar-toggler-icon"></span>
           </button>

--- a/docs/lookuptimezonetime.html
+++ b/docs/lookuptimezonetime.html
@@ -12,7 +12,7 @@
 
         <nav class="navbar navbar-expand-sm bg-dark navbar-dark">
             <div class="container-fluid">
-              <a class="navbar-brand" href="index.html">Navbar</a>
+              <a class="navbar-brand" href="index.html">TimeConv</a>
               <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#collapsibleNavbar">
               <span class="navbar-toggler-icon"></span>
               </button>

--- a/docs/time_conversion_links.html
+++ b/docs/time_conversion_links.html
@@ -13,7 +13,7 @@
     <body>
       <nav class="navbar navbar-expand-sm bg-dark navbar-dark">
         <div class="container-fluid">
-          <a class="navbar-brand" href="index.html">Navbar</a>
+          <a class="navbar-brand" href="index.html">TimeConv</a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#collapsibleNavbar">
           <span class="navbar-toggler-icon"></span>
           </button>

--- a/docs/utcsecondstodatetime.html
+++ b/docs/utcsecondstodatetime.html
@@ -13,7 +13,7 @@
 
          <nav class="navbar navbar-expand-sm bg-dark navbar-dark">
             <div class="container-fluid">
-              <a class="navbar-brand" href="index.html">Navbar</a>
+              <a class="navbar-brand" href="index.html">TimeConv</a>
               <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#collapsibleNavbar">
               <span class="navbar-toggler-icon"></span>
               </button>


### PR DESCRIPTION
Fix #51 

I have corrected the `navbar-brand` in all html pages to use **TimeConv** instead of **Navbar**.