### PR TITLE
fix(docs): make footer sticky and layout responsive on mobile

### DIFF
--- a/docs/cdits.css
+++ b/docs/cdits.css
@@ -1,6 +1,11 @@
-html, body {
+html {
   height: 100%;
-  width: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 * {
@@ -29,18 +34,15 @@ ion-icon {
 }
 
 footer {
+  margin-top: auto;
   color: ghostwhite;
-  right: 0%;
-  position: absolute;
   text-align: center;
   background-color: #666666;
   font-family: 'Yellowtail', cursive;
   box-sizing: border-box;
-  height: 15vh;
   width: 100%;
-  bottom: 0;
-  
-} 
+  padding: 1rem 0;
+}
 
 /* Mobile Responsivness */
 

--- a/docs/credits.html
+++ b/docs/credits.html
@@ -1,62 +1,55 @@
 <!DOCTYPE html>
-<html>
-   <html lang="en-US">
-      <head>
-         <meta charset="utf-8">
-         <meta name="viewport" content="width=device-width, initial-scale=1">
-         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
-         <link rel="stylesheet" href="cdits.css">
-         <link rel="icon" type="image/x-icon" href="favicon.ico"/>
-      </head>
-      <body>
-         <nav class="navbar navbar-expand-sm bg-dark navbar-dark">
-            <div class="container-fluid">
-               <a class="navbar-brand" href="index.html">TimeConv</a>
-               <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#collapsibleNavbar">
-               <span class="navbar-toggler-icon"></span>
-               </button>
-               <div class="collapse navbar-collapse" id="collapsibleNavbar">
-                  <ul class="navbar-nav">
-                     <li class="nav-item">
-                        <a class="nav-link" href="time_conversion_links.html">Time Conversion Links</a>
-                     </li>
-                     <li class="nav-item">
-                        <a class="nav-link" href="credits.html">Credits</a>
-                     </li>
-                     <li class="nav-item">
-                        <a class="nav-link" href="legal/branding.html">Branding</a>
-                     </li>
-                  </ul>
-               </div>
-            </div>
-         </nav>
-         <title>TimeConv - Credits</title>
-         <div class="container-fluid p-5 bg-primary text-white text-center">
-            <h1>Credits</h1>
-         </div>
-         <div class="container mt-5">
-            <div class="row">
-               <br>  
-               <h1>Credits</h1>
-               </br>  
-               <div class="container MT-5">
-                  <div class="row">
-                     <h2>Check out the credits on our <a href="https://github.com/ArjunSharda/TimeConv/blob/main/CREDITS.md">GitHub</a>!</h2>
-                     <footer>
-                        <h2>Project Information</h2>
-                        <a href="https://github.com/ArjunSharda/TimeConv/" target="_blank">
-                           <ion-icon name="logo-github" size="large"></ion-icon>
-                        </a>
-                        <a href="https://discord.gg/qWezfjAq6h" target="_blank">
-                           <ion-icon name="logo-discord" size="large"></ion-icon>
-                        </a>
-                     </footer>
-                     <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
-                     <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>  
-      </body>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>TimeConv - Credits</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+    <link rel="stylesheet" href="cdits.css">
+    <link rel="icon" type="image/x-icon" href="favicon.ico"/>
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-sm bg-dark navbar-dark">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="index.html">TimeConv</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#collapsibleNavbar">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="collapsibleNavbar">
+          <ul class="navbar-nav">
+            <li class="nav-item">
+              <a class="nav-link" href="time_conversion_links.html">Time Conversion Links</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="credits.html">Credits</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="legal/branding.html">Branding</a>
+            </li>
+          </ul>
+        </div>
       </div>
+    </nav>
+    <div class="container-fluid p-5 bg-primary text-white text-center">
+      <h1>Credits</h1>
+    </div>
+    <div class="container mt-5">
+      <div class="row">
+        <h1>Credits</h1>
+        <h2>Check out the credits on our <a href="https://github.com/ArjunSharda/TimeConv/blob/main/CREDITS.md">GitHub</a>!</h2>
       </div>
-      </div>
-      </div>
-   </html>
+    </div>
+    <footer>
+      <h2>Project Information</h2>
+      <a href="https://github.com/ArjunSharda/TimeConv/" target="_blank">
+        <ion-icon name="logo-github" size="large"></ion-icon>
+      </a>
+      <a href="https://discord.gg/qWezfjAq6h" target="_blank">
+        <ion-icon name="logo-discord" size="large"></ion-icon>
+      </a>
+    </footer>
+    <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
+    <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>
+  </body>
+</html>

--- a/docs/dttu.css
+++ b/docs/dttu.css
@@ -1,8 +1,12 @@
-/* html, body {
+html {
   height: 100%;
-  width: 100%;
-} */
+}
 
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
 * {
   padding: 0;
   margin: 0;
@@ -20,6 +24,7 @@ h1 {
 }
 input {
   height: 5vh;
+  max-width: 100%;
   box-sizing: border-box;
   border-radius: 4px;
 }
@@ -51,17 +56,14 @@ ion-icon {
 }
 
 footer {
+  margin-top: auto;
   color: ghostwhite;
-  right: 0%;
-  position: absolute;
   text-align: center;
   background-color: #666666;
   font-family: 'Yellowtail', cursive;
   box-sizing: border-box;
-  height: 15vh;
   width: 100%;
-  bottom: 0;
-  
+  padding: 1rem 0;
 }
 
 /* Mobile Responsiveness */

--- a/docs/legal/brandingcss.css
+++ b/docs/legal/brandingcss.css
@@ -1,6 +1,11 @@
-html, body {
+html {
   height: 100%;
-  width: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 * {
@@ -54,14 +59,12 @@ ion-icon {
 }
 
 footer {
+  margin-top: auto;
   color: ghostwhite;
-  right: 0%;
-  position: absolute;
   text-align: center;
   background-color: #666666;
   font-family: 'Yellowtail', cursive;
   box-sizing: border-box;
-  height: 15vh;
   width: 100%;
-  bottom: 0;
-  
+  padding: 1rem 0;
+}

--- a/docs/tcl.css
+++ b/docs/tcl.css
@@ -1,6 +1,11 @@
-html, body {
+html {
   height: 100%;
-  width: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 * {
@@ -19,16 +24,14 @@ h1 {
 }
 
 footer {
+  margin-top: auto;
   color: ghostwhite;
-  right: 0%;
-  position: absolute;
   text-align: center;
   background-color: #666666;
   font-family: 'Yellowtail', cursive;
   box-sizing: border-box;
-  height: 15vh;
   width: 100%;
-  bottom: 0;
+  padding: 1rem 0;
 }
 
 ion-icon {

--- a/docs/ustdt.css
+++ b/docs/ustdt.css
@@ -1,8 +1,12 @@
-/* html, body {
+html {
   height: 100%;
-  width: 100%;
-} */
+}
 
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
 * {
   padding: 0;
   margin: 0;
@@ -20,6 +24,7 @@ h1 {
 }
 input {
   height: 5vh;
+  max-width: 100%;
   box-sizing: border-box;
   border-radius: 4px;
 }
@@ -51,15 +56,12 @@ ion-icon {
 }
 
 footer {
+  margin-top: auto;
   color: ghostwhite;
-  right: 0%;
-  position: absolute;
   text-align: center;
   background-color: #666666;
   font-family: 'Yellowtail', cursive;
   box-sizing: border-box;
-  height: 15vh;
   width: 100%;
-  bottom: 0;
-  
+  padding: 1rem 0;
 }

--- a/docs/utcsecondstodatetime.html
+++ b/docs/utcsecondstodatetime.html
@@ -1,4 +1,3 @@
-Utcsecondstodatetime.html · CORRIGIDO
 <!DOCTYPE html>
 <html lang="en-US">
   <head>

--- a/docs/utcsecondstodatetime.html
+++ b/docs/utcsecondstodatetime.html
@@ -1,79 +1,75 @@
-<html>
-  <html lang="en-US">
-    <head>
-      <title>TimeConv - UTC Seconds to date time converter</title>
-      <link rel="icon" type="image/x-icon" href="favicon.ico"/>
-    <body>
-      <meta charset="utf-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1">
-      <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-      <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
-      <link rel="stylesheet" href="ustdt.css">
-      </head>
-
-         <nav class="navbar navbar-expand-sm bg-dark navbar-dark">
-            <div class="container-fluid">
-              <a class="navbar-brand" href="index.html">TimeConv</a>
-              <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#collapsibleNavbar">
-              <span class="navbar-toggler-icon"></span>
-              </button>
-              <div class="collapse navbar-collapse" id="collapsibleNavbar">
-                  <ul class="navbar-nav">
-                    <li class="nav-item">
-                        <a class="nav-link" href="time_conversion_links.html">Time Conversion Links</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="credits.html">Credits</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="legal/branding.html">Branding</a>
-                    </li>
-                  </ul>
-            
-              </div>
-            </div>
-           </div>
-        </nav>
-      </div>
-
-        <!--main content -->
-            <div class="container-fluid p-5 bg-primary text-white text-center">
-          <div class="container">
-        <form id="utcsecondstodatetime">
-          Enter seconds (example: 1655864817):
-          <input name="name" type="text" size="30"> 
-          <button onclick="utcsecondstodatetime()" class="submit_btn">Submit</button> 
-        </form>
-        <script>
-          function utcsecondstodatetime() {
-            var x2, y2;
-            x2 = document.getElementById("utcsecondstodatetime");
-            y2 = x2.elements["name"].value;
-            if (!y2) {
-              document.getElementById("utcsecondstodatetime").innerHTML = "Invalid Date";
-            }
-            else {
-              const dateutdt2 = new Date(y2*1000);
-              document.getElementById("utcsecondstodatetime").innerHTML = dateutdt2.toLocaleString();
-            }
-          }   
-        </script> 
-          </div>
-          </div>
-          </div>
-  </div>
-</div>
+Utcsecondstodatetime.html · CORRIGIDO
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>TimeConv - UTC Seconds to date time converter</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+    <link rel="stylesheet" href="ustdt.css">
+    <link rel="icon" type="image/x-icon" href="favicon.ico"/>
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-sm bg-dark navbar-dark">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="index.html">TimeConv</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#collapsibleNavbar">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="collapsibleNavbar">
+          <ul class="navbar-nav">
+            <li class="nav-item">
+              <a class="nav-link" href="time_conversion_links.html">Time Conversion Links</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="credits.html">Credits</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="legal/branding.html">Branding</a>
+            </li>
+          </ul>
         </div>
-         <footer>
-          <h2>Project Information</h2>
-          <a href="https://github.com/ArjunSharda/TimeConv/" target="_blank">
-            <ion-icon name="logo-github" size="large"></ion-icon>
-          </a>
-          <a href="https://discord.gg/qWezfjAq6h" target="_blank">
-            <ion-icon name="logo-discord" size="large"></ion-icon>
-          </a>
-        </footer>
-        <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
-        <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>  
-    </body>
-  </html>
+      </div>
+    </nav>
+ 
+    <!--main content -->
+    <div class="container-fluid p-5 bg-primary text-white text-center">
+      <h1>Converter: UTC seconds to date time</h1>
+    </div>
+    <div class="container mt-5">
+      <form id="utcsecondstodatetime">
+        <span>Enter seconds (example: 1655864817):</span>
+        <input name="name" type="text" size="30">
+        <button onclick="utcsecondstodatetime()" class="submit_btn">Submit</button>
+      </form>
+      <script>
+        function utcsecondstodatetime() {
+          var x2, y2;
+          x2 = document.getElementById("utcsecondstodatetime");
+          y2 = x2.elements["name"].value;
+          if (!y2) {
+            document.getElementById("utcsecondstodatetime").innerHTML = "Invalid Date";
+          }
+          else {
+            const dateutdt2 = new Date(y2*1000);
+            document.getElementById("utcsecondstodatetime").innerHTML = dateutdt2.toLocaleString();
+          }
+        }
+      </script>
+    </div>
+    <!-- end of main content -->
+ 
+    <footer>
+      <h2>Project Information</h2>
+      <a href="https://github.com/ArjunSharda/TimeConv/" target="_blank">
+        <ion-icon name="logo-github" size="large"></ion-icon>
+      </a>
+      <a href="https://discord.gg/qWezfjAq6h" target="_blank">
+        <ion-icon name="logo-discord" size="large"></ion-icon>
+      </a>
+    </footer>
+    <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
+    <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #41

**Problem:** the footer used `position: absolute; bottom: 0; height: 15vh`, so it left the document flow and overlapped page content, and the fixed `15vh` clipped its own contents on short viewports. In `credits.html` the `<footer>` was nested four levels deep inside Bootstrap `.row` containers, and in `utcsecondstodatetime.html` it sat outside `<body>` altogether (the `<body>` tag was opened inside `<head>`) — so it could not be positioned by CSS at all. Fixed-width inputs (`size="30"`) inside `.p-5` containers also caused horizontal scrolling below ~400px.

**Fix:** applied the flex sticky-footer pattern already used in `lookuptimezonetime.html` (`body` as a flex column with `min-height: 100vh`, `footer { margin-top: auto }`) to `cdits.css`, `dttu.css`, `tcl.css`, `ustdt.css` and `legal/brandingcss.css`; moved `<footer>` to be the last child of `<body>` in the two broken pages and fixed their duplicated `<html>` tags and stray `</div>`s; added `max-width: 100%` to the inputs. No new dependencies, JS untouched.

**Tested at** 320px / 375px / 768px and desktop, on every page.

<img width="1662" height="983" alt="image" src="https://github.com/user-attachments/assets/245eaffb-7451-430b-ae79-a57dbb3ad555" />

<img width="725" height="984" alt="image" src="https://github.com/user-attachments/assets/6712b1c9-1f4a-4071-8d98-3ee0b77ea6a5" />

<img width="725" height="984" alt="image" src="https://github.com/user-attachments/assets/79c43e86-c806-4b40-9d36-c19cba5e1a7b" />

<img width="1656" height="982" alt="image" src="https://github.com/user-attachments/assets/514be916-74ee-4205-8163-17e5432d3eb4" />

