### PR TITLE
fix(docs): keep converter forms usable after submitting

### DIFF
--- a/docs/datetimetoutc.html
+++ b/docs/datetimetoutc.html
@@ -41,16 +41,17 @@
       <div class="row">
       <form id="datetimetoutc">
             <span>Enter time: (example: 15 Jun 2020 5:30:00 CDT)</span>
-            <input name="name" type="text"> 
-            <button onclick="datetimetoutc();" class="submit_btn">Submit</button>  
+            <input name="name" type="text">
+            <button type="button" onclick="datetimetoutc();" class="submit_btn">Submit</button>
       </form>
+      <p id="datetimetoutc-result"></p>
       <script>
         function datetimetoutc() {
           var x,y;
           x = document.getElementById("datetimetoutc");
           y = x.elements["name"].value;
           let dateutdt = new Date(y);
-          document.getElementById("datetimetoutc").innerHTML = dateutdt.toUTCString();
+          document.getElementById("datetimetoutc-result").innerHTML = dateutdt.toUTCString();
         }
             
       </script>

--- a/docs/lookuptimezonetime.html
+++ b/docs/lookuptimezonetime.html
@@ -49,8 +49,9 @@
                 <input name="name" type="text" size="30" placeholder="en-US">
                 <input name="name2" type="text" size="30" placeholder="UTC">
                 <input name="name3" type="text" size="30" placeholder="6/23/2022 20:00:00)">  
-                <button onclick="lookuptimezonetime()" class="submit_btn">Submit</button>  
+                <button type="button" onclick="lookuptimezonetime()" class="submit_btn">Submit</button>
             </form>
+            <p id="lookuptimezonetime-result"></p>
             </div>
           </div>
         </main>
@@ -75,7 +76,15 @@
             a2 = x2.elements["name2"].value;
             b2 = x2.elements["name3"].value;
             let datetime = new Date(b2);
-            document.getElementById("lookuptimezonetime").innerHTML = datetime.toLocaleString(y2, { timeZone: a2});
+            if (isNaN(datetime.getTime())) {
+              document.getElementById("lookuptimezonetime-result").innerHTML = "Invalid Date";
+              return;
+            }
+            try {
+              document.getElementById("lookuptimezonetime-result").innerHTML = datetime.toLocaleString(y2, { timeZone: a2});
+            } catch (e) {
+              document.getElementById("lookuptimezonetime-result").innerHTML = "Invalid Date";
+            }
           }   
         </script> 
         <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>

--- a/docs/utcsecondstodatetime.html
+++ b/docs/utcsecondstodatetime.html
@@ -40,19 +40,20 @@
       <form id="utcsecondstodatetime">
         <span>Enter seconds (example: 1655864817):</span>
         <input name="name" type="text" size="30">
-        <button onclick="utcsecondstodatetime()" class="submit_btn">Submit</button>
+        <button type="button" onclick="utcsecondstodatetime()" class="submit_btn">Submit</button>
       </form>
+      <p id="utcsecondstodatetime-result"></p>
       <script>
         function utcsecondstodatetime() {
           var x2, y2;
           x2 = document.getElementById("utcsecondstodatetime");
           y2 = x2.elements["name"].value;
           if (!y2) {
-            document.getElementById("utcsecondstodatetime").innerHTML = "Invalid Date";
+            document.getElementById("utcsecondstodatetime-result").innerHTML = "Invalid Date";
           }
           else {
             const dateutdt2 = new Date(y2*1000);
-            document.getElementById("utcsecondstodatetime").innerHTML = dateutdt2.toLocaleString();
+            document.getElementById("utcsecondstodatetime-result").innerHTML = dateutdt2.toLocaleString();
           }
         }
       </script>


### PR DESCRIPTION
Closes #64

**Problem:** as described in the issue, the three converter pages had two defects
that masked each other. The submit buttons had no `type`, so they defaulted to
`type="submit"`; and the handlers wrote their result into the `<form>` element
itself, wiping out the input and button after a single conversion.

**Fix:** added `type="button"` to the three converter buttons, and gave each page
a dedicated `<p>` for the result so the form survives. In
`lookuptimezonetime.html` an invalid timezone or locale made `toLocaleString`
throw — which is what exposed the submit defect — so that case now reports
"Invalid Date" instead of failing silently.

**On the asymmetry between the three files:** each page already handled errors
differently before this PR (`utcsecondstodatetime.html` checks for empty input,
`datetimetoutc.html` relies on `toUTCString()` returning "Invalid Date"). I kept
those as they were and only added handling where something was actually broken,
to keep the diff focused. Happy to unify them if you'd prefer.

**Tested** locally on all three converters: repeated conversions without a
reload, empty input, invalid date, and invalid timezone. No page reloads and no
query strings appended in any case.

<img width="1169" height="834" alt="image" src="https://github.com/user-attachments/assets/b7574871-72b0-43e7-9420-375493b71a51" />

<img width="1169" height="834" alt="image" src="https://github.com/user-attachments/assets/ad8864b3-f9f5-4b2e-a76c-600b1f55aa67" />


<img width="1169" height="834" alt="image" src="https://github.com/user-attachments/assets/d66e6b07-f655-41da-834c-d5ec5d1b7e9e" />
